### PR TITLE
Use zlib and libpng modules from runtime

### DIFF
--- a/com.zquestclassic.ZQuest.yml
+++ b/com.zquestclassic.ZQuest.yml
@@ -57,8 +57,8 @@ modules:
       - -D FETCHCONTENT_SOURCE_DIR_ASMJIT=../deps/asmjit
       - -D FETCHCONTENT_SOURCE_DIR_NATIVEFILEDIALOG=../deps/nfd
       - -D FETCHCONTENT_SOURCE_DIR_JSON=../deps/json
-      - -D FETCHCONTENT_SOURCE_DIR_ZLIB=../deps/zlib
-      - -D FETCHCONTENT_SOURCE_DIR_PNG=../deps/libpng
+      - -D WANT_VENDORED_ZLIB
+      - -D WANT_VENDORED_LIBPNG
       - -D FETCHCONTENT_SOURCE_DIR_STDUUID=../deps/stduuid
     sources:
       - type: git

--- a/com.zquestclassic.ZQuest.yml
+++ b/com.zquestclassic.ZQuest.yml
@@ -91,16 +91,16 @@ modules:
         url: https://github.com/btzy/nativefiledialog-extended
         tag: 17b6e8ce219c0677f94b63636abb9296b28841ca
         dest: deps/nfd
-      - type: git
-        url: https://github.com/madler/zlib
-        tag: v1.3.1
-        commit: 51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf
-        dest: deps/zlib
-      - type: git
-        url: https://github.com/glennrp/libpng
-        tag: v1.6.47
-        commit: 872555f4ba910252783af1507f9e7fe1653be252
-        dest: deps/libpng
+      # - type: git
+      #   url: https://github.com/madler/zlib
+      #   tag: v1.3.1
+      #   commit: 51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf
+      #   dest: deps/zlib
+      # - type: git
+      #   url: https://github.com/glennrp/libpng
+      #   tag: v1.6.47
+      #   commit: 872555f4ba910252783af1507f9e7fe1653be252
+      #   dest: deps/libpng
       - type: git
         url: https://github.com/mariusbancila/stduuid
         tag: 3afe7193facd5d674de709fccc44d5055e144d7a


### PR DESCRIPTION
Freedesktop runtime version 23.08 appears to provide the zlib and libpng modules.

In most cases, you don't need to build these modules separately, unless your project requires a specific version or a custom configuration.

**Related manifest files**

- https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/23.08/elements/bootstrap/zlib.bst
- https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/23.08/elements/components/libpng.bst?ref_type=heads